### PR TITLE
Add webpack dev server and hot module replacement for web environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,5 @@ npm run dev
 npm run tns -- run android # wip this won't be required later
 
 # terminal 3
-# for the web version, there is no dev-server configured yet so:
-cd dist/web
-serve
+# for the web version, a dev-server is configured with HMR on port 8080:
+`npm run dev:server`

--- a/build/webpack.config.web.js
+++ b/build/webpack.config.web.js
@@ -1,10 +1,15 @@
 const utils = require('./utils')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const DefinePlugin = require('webpack/lib/DefinePlugin')
+const webpack = require('webpack')
 
 module.exports = {
   target: 'web',
   entry: utils.srcPath('entry.web.js'),
+  devServer: {
+    contentBase: './dist',
+    hot: true,
+  },
   output: {
     filename: 'app.bundle.js',
     path: utils.distPath('web')
@@ -29,6 +34,8 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: utils.srcPath('index.html')
-    })
+    }),
+    new webpack.NamedModulesPlugin(),
+    new webpack.HotModuleReplacementPlugin()
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:ios": "npm run webpack -- --env.platform=ios",
     "build:android": "npm run webpack -- --env.platform=android",
     "dev": "npm run webpack -- --watch",
+    "dev:server": "webpack-dev-server --config build/webpack.config.js --env.platform=web --open --watch",
     "dev:web": "npm run webpack -- --env.platform=web --watch",
     "dev:native": "npm run webpack -- --env.platform=ios --env.platform=android --watch",
     "dev:ios": "npm run webpack -- --env.platform=ios --watch",
@@ -30,6 +31,7 @@
     "nativescript-vue-template-compiler": "^0.7.9",
     "vue-template-compiler": "^2.5.13",
     "webpack": "^3.10.0",
+    "webpack-dev-server": "^2.11.1",
     "webpack-merge": "^4.1.1",
     "webpack-pre-emit-plugin": "^0.1.0"
   },


### PR DESCRIPTION
👋 I'm a big fan of this WIP and thrilled to see it grow !

This PR adds a simple dev server and HMR for web platform development.

The command dev:server fires up a server listening on port 8080.